### PR TITLE
Show background in full screen

### DIFF
--- a/MOON SHOT/MOON SHOT/ContentView.swift
+++ b/MOON SHOT/MOON SHOT/ContentView.swift
@@ -67,11 +67,9 @@ struct ContentView: View {
                     .font(.system(size: 10))
             }
             }
-            .padding()
-            
+            .edgesIgnoringSafeArea(.all)
         }
     }
-        
 }
 
 struct ContentView_Previews: PreviewProvider {


### PR DESCRIPTION
背景を画像いっぱいにする

画面の端に空白ができてしまったのはPaddingを設定していたことと、SafeAreaが原因。

Paddingの削除とSafeAreaを無視してレイアウトをする設定の追加を行なった

|修正前|Paddingを削除|SafeAreaを無視|
|:---|:---|:---|
|![Simulator Screenshot - iPhone 14 Pro - 2023-09-24 at 00 49 20](https://github.com/Yoriaki11/MOONSHOT/assets/2178775/00114394-f531-4ebf-8d4d-bba888f8d7c4)|![Simulator Screenshot - iPhone 14 Pro - 2023-09-24 at 00 49 09](https://github.com/Yoriaki11/MOONSHOT/assets/2178775/10153af4-db4e-4872-9169-f9a2e8dda418)|![Simulator Screenshot - iPhone 14 Pro - 2023-09-24 at 00 49 02](https://github.com/Yoriaki11/MOONSHOT/assets/2178775/8b373b1f-c5fb-44f3-a1d0-ab7c8220f2c9)|

